### PR TITLE
fix #42 allow null/undefined/'' as range strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,10 +71,19 @@ DB.prototype._batch = function (ops, opts, cb) {
   this.db.batch(ops, opts, cb)
 }
 
-DB.prototype._iterator = function (opts) {
-  opts.keyAsBuffer = this.codec.keyAsBuffer(opts)
-  opts.valueAsBuffer = this.codec.valueAsBuffer(opts)
-  return new Iterator(this, opts)
+DB.prototype.iterator = function (options) {
+  options = options || {}
+  options.reverse = !!options.reverse
+  options.keys = options.keys !== false
+  options.values = options.values !== false
+  options.limit = 'limit' in options ? options.limit : -1
+  options.keyAsBuffer = options.keyAsBuffer !== false
+  options.valueAsBuffer = options.valueAsBuffer !== false
+
+  options.keyAsBuffer = this.codec.keyAsBuffer(options)
+  options.valueAsBuffer = this.codec.valueAsBuffer(options)
+
+  return new Iterator(this, options)
 }
 
 DB.prototype.approximateSize = function (start, end, opts, cb) {


### PR DESCRIPTION
this restores full support for bytewise (and charwise) encodings, and fixes #42.
This passes leveldown tests, and level tests with encoding-down linked in.

and also passes tests for: https://github.com/flumedb/flumeview-level/issues/11#issuecomment-389550324

*Edit: added issue reference (@vweevers)*