### PR TITLE
override _setupIteratorOptions, without clobbering ranges

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,17 @@ DB.prototype._iterator = function (opts) {
   return new Iterator(this, opts)
 }
 
+// TODO refactor this with the code in abstract-leveldown
+DB.prototype._setupIteratorOptions = function (options) {
+  options.reverse = !!options.reverse
+  options.keys = options.keys !== false
+  options.values = options.values !== false
+  options.limit = 'limit' in options ? options.limit : -1
+  options.keyAsBuffer = options.keyAsBuffer !== false
+  options.valueAsBuffer = options.valueAsBuffer !== false
+  return options
+}
+
 DB.prototype.approximateSize = function (start, end, opts, cb) {
   return this.db.approximateSize(start, end, opts, cb)
 }


### PR DESCRIPTION
follows the patterns in https://github.com/Level/encoding-down/pull/44 except it preserves ranges.

I'm a little wary of doing it this way, because `_setupIteratorOptions` is not an official public api of leveldown (not mentioned in the documentation). I've already been bitten by depending on obsecure edgecases in level, that have been removing in the course of routine maintainence. I would be more confidant about the stability of https://github.com/Level/encoding-down/pull/43/files because I know `iterator` isn't going anywere. But I can easily imagine someone forgetting about _setupIteratorOptions, refactoring it, and this then stops working.